### PR TITLE
😰itemテーブルのダミーデータ作成時のミス修正

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,7 +57,7 @@ ITEM_TABLE_MAX.times do |n|
     category_id:      Random.new.rand(1..13),
     brand_id:         Random.new.rand(1..6),
     prefecture_id:    Random.new.rand(1..47),
-    price:            123456789,
+    price:            9999999,
     user_id:          Random.new.rand(1..USER_TABLE_MAX),
     #列挙型で定義したカラム
     status:           Random.new.rand(Item.statuses.size),


### PR DESCRIPTION
## 修正内容
メルカリ本家では価格設定の範囲は「300以上 9,999,999以下」なのに
上限を超えた値をダミーデータとして格納していたので修正しました。

以下は本家の出品画面
![スクリーンショット 2019-03-24 19 49 50](https://user-images.githubusercontent.com/32605128/54878296-ffb58a00-4e6d-11e9-9712-716e1d3601d9.png)
