### PR TITLE
✍Railsアプリ専用の環境変数を管理するgemを追加

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+PAYJP_PUBLIC_KEY=(*´ﾉД｀)ﾋﾐﾂﾀﾞｮ★
+PAYJP_SECRET_KEY=(*´ﾉД｀)ﾋﾐﾂﾀﾞｮ★

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 config/omniauth.yml
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'enum_help'
 gem 'faker'
 gem 'rails-i18n', '~> 5.1'
 gem 'gretel'
+gem 'dotenv-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    dotenv (2.7.1)
+    dotenv-rails (2.7.1)
+      dotenv (= 2.7.1)
+      railties (>= 3.2, < 6.1)
     enum_help (0.0.17)
       activesupport (>= 3.0.0)
     erb2haml (0.1.5)
@@ -343,6 +347,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  dotenv-rails
   enum_help
   erb2haml
   factory_bot_rails


### PR DESCRIPTION
## 対応内容
- `dotenv-rails`gemを追加。
- 環境変数は`.env`ファイルに定義するが公開したくないので`.gitignore`に設定追加。
- 公開用に`.env.sample`ファイルを新規作成した。

## 参考にしたサイト
http://vdeep.net/rubyonrails-dotenv