### PR TITLE
Itemsell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 config/omniauth.yml
+public/uploads/*

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem 'active_hash'
 gem 'enum_help'
 gem 'faker'
 gem 'rails-i18n', '~> 5.1'
+gem 'carrierwave'
+gem 'mini_magick'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,10 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
+    carrierwave (1.3.1)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      mime-types (>= 1.16)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (2.1.0)
@@ -162,7 +166,11 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mimemagic (0.3.3)
+    mini_magick (4.9.2)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -338,6 +346,7 @@ DEPENDENCIES
   capistrano-rbenv
   capistrano3-unicorn
   capybara (>= 2.15)
+  carrierwave
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
@@ -351,6 +360,7 @@ DEPENDENCIES
   jquery-rails
   jquery-slick-rails
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)
   omniauth
   omniauth-facebook

--- a/app/assets/javascripts/item_new.js
+++ b/app/assets/javascripts/item_new.js
@@ -15,7 +15,7 @@ $(document).on('turbolinks:load', function(){
   }
 
   function appendInputField(isImgId){
-    var html =`<input id="is-img-${isImgId+1}" multiple="multiple"  data-id="${isImgId+1}" class="is-upload-box-container__box--file" type="file" name="item_form[image][]">`
+    var html =`<input id="is-img-${isImgId+1}" multiple="multiple"  data-id="${isImgId+1}" class="is-upload-box-container__box--file" type="file" name="item_form[images][]">`
   inputFieldList.append(html);
   }
 

--- a/app/assets/javascripts/item_new.js
+++ b/app/assets/javascripts/item_new.js
@@ -1,0 +1,174 @@
+$(document).on('turbolinks:load', function(){
+
+  var inputFieldList = $(".is-add-up")
+ function appendImage(img,i,imageList) {
+   var html = `<li class="is-image-li" id="${i}">
+                <figure class="is-image-li__figure">
+                  <img src="${img}">
+                </figure>
+                <div class="is-image-li__under">
+                  <a href="#" class="is-image-li__under--e">編集<a>
+                  <a href="#" class="is-image-li__under--e">削除<a>
+                </div>
+              </li>`
+   imageList.append(html);
+  }
+
+  function appendInputField(isImgId){
+    var html =`<input id="is-img-${isImgId+1}" multiple="multiple"  data-id="${isImgId+1}" class="is-upload-box-container__box--file" type="file" name="item_form[image][]">`
+  inputFieldList.append(html);
+  }
+
+  function addClass(){
+    switch (imgCount){
+      case 1:
+        $("#is-add").addClass("is-item-1");
+        break;
+      case 2:
+        $("#is-add").addClass("is-item-2");
+        break;
+      case 3:
+        $("#is-add").addClass("is-item-3");
+        break;
+      case 4:
+        $("#is-add").addClass("is-item-4");
+        break;
+      case 5:
+        $("#is-add").addClass("is-item-5");
+        break;
+      case 6:
+        $("#is-add").addClass("is-item-1");
+        break;
+      case 7:
+        $("#is-add").addClass("is-item-2");
+        break;
+      case 8:
+        $("#is-add").addClass("is-item-3");
+        break;
+      case 9:
+        $("#is-add").addClass("is-item-4");
+        break;
+      case 10:
+        $("#is-add").addClass("is-item-5");
+        break;
+    }
+  }
+
+    function removeClass(imgCount){
+    switch (imgCount){
+      case 1:
+        $("#is-add").removeClass("is-item-1");
+        break;
+      case 2:
+        $("#is-add").removeClass("is-item-2");
+        break;
+      case 3:
+        $("#is-add").removeClass("is-item-3");
+        break;
+      case 4:
+        $("#is-add").removeClass("is-item-4");
+        break;
+      case 5:
+        $("#is-add").removeClass("is-item-5");
+        break;
+      case 6:
+        $("#is-add").removeClass("is-item-1");
+        break;
+      case 7:
+        $("#is-add").removeClass("is-item-2");
+        break;
+      case 8:
+        $("#is-add").removeClass("is-item-3");
+        break;
+      case 9:
+        $("#is-add").removeClass("is-item-4");
+        break;
+      case 10:
+        $("#is-add").removeClass("is-item-5");
+        break;
+    }
+  }
+
+
+// 未アップロード時のラベルのforを取得する
+     isLabelFor = $(".is-upload-box-container").find("#is-add").attr("for");
+// ファイルの初期化
+     file = ""
+
+     isCount = 0
+     imgCount = 0
+//
+// ラベルのforと同じIDのファイルアップローダーが開いた時に発火する///////////////////////
+  $(".is-upload-box-container").change(`#${isLabelFor}`,function(e){
+    e.preventDefault();
+// アップローダーのdata-idを取得
+      var isImgId = $(this).find(`#${isLabelFor}`).data('id');
+// アップローダーで選択したimageファイルを取得
+     file = $(this).find(`#${isLabelFor}`).prop('files')[0];
+
+     var permitType = ['image/jpeg', 'image/png', 'image/gif'];
+            if (file && permitType.indexOf(file.type) == -1) {
+                alert('この形式のファイルはアップロードできません');
+                $(this).find(`#${isLabelFor}`).val('');
+                return
+              }
+      var reader = new FileReader()
+      reader.onload = function(e){
+      var imgName = e.target.result;
+// 取得したimgをプレビューさせる
+      if (imgCount >= 5){
+        imageList = $("#is-image-ul-2");
+        } else {
+        imageList = $("#is-image-ul-1");
+        }
+      appendImage(imgName,isLabelFor,imageList);
+//次のアップローダーを追加する
+      appendInputField(isImgId);
+//viewの幅を変更させるクラスの追加
+    if (imgCount < 9){
+      console.log("aaa");
+      removeClass(imgCount)
+      imgCount = imgCount + 1
+      addClass(imgCount)
+    } else {
+      console.log("bbb");
+      imgCount = imgCount + 1
+      $("#is-add").removeClass();
+      $(".is-upload-box-container__box--text").text("");
+    }
+//次の画像を選択させるためにlabelのforを変更
+      $("#is-add").attr("for",`is-img-${isImgId+1}`);
+//変更後のlabelのforを取得
+       isLabelFor = $(".is-upload-box-container").find("#is-add").attr("for")
+       isCount = isCount + 1
+       console.log(imgCount)
+  }
+    reader.readAsDataURL(file);
+  });
+////////////////////////////////////////////////////////////////////////////////
+//
+////削除ボタンの処理//////////////////////////////////////////////////////////////
+  $(".is-upload-box-container").on("click",".is-image-li__under--e",function(e){
+    e.preventDefault();
+    console.log(imgCount)
+    isCount = isCount -1
+//削除対象のliのIDを取得
+    var imgId = $(this).parent().parent().attr("id");
+//liのidに紐づくinputタグのdata-idを取得
+    var imgNo = $(".is-add-up").find(`#${imgId}`).data('id');
+    if (imgCount < 10){
+      removeClass(imgCount)
+      imgCount = imgCount - 1
+      addClass(imgCount)
+    } else {
+      imgCount = imgCount - 1
+      $("#is-add").addClass("is-upload-box-container__box is-item-4");
+      $(".is-upload-box-container__box--text").text("ドラッグアンドドロップまたはクリックしてファイルをアップロード");
+    }
+    $(this).parent().parent().remove();
+    // $("#is-add").addClass(`is-item-${imgCount}`).removeClass(`is-item-${imgCount+1}`);
+    $(".is-add-up").find(`#${imgId}`).remove();
+  })
+//////////////////////////////////////////////////////////////////////////////////
+
+});

--- a/app/assets/javascripts/item_new.js
+++ b/app/assets/javascripts/item_new.js
@@ -159,7 +159,6 @@ $(document).on('turbolinks:load', function(){
       $(".is-upload-box-container__box--text").text("ドラッグアンドドロップまたはクリックしてファイルをアップロード");
     }
     $(this).parent().parent().remove();
-    // $("#is-add").addClass(`is-item-${imgCount}`).removeClass(`is-item-${imgCount+1}`);
     $(".is-add-up").find(`#${imgId}`).remove();
   })
 //////////////////////////////////////////////////////////////////////////////////

--- a/app/assets/javascripts/item_new.js
+++ b/app/assets/javascripts/item_new.js
@@ -95,7 +95,6 @@ $(document).on('turbolinks:load', function(){
 // ファイルの初期化
      file = ""
 
-     isCount = 0
      imgCount = 0
 //
 // ラベルのforと同じIDのファイルアップローダーが開いた時に発火する///////////////////////
@@ -126,12 +125,10 @@ $(document).on('turbolinks:load', function(){
       appendInputField(isImgId);
 //viewの幅を変更させるクラスの追加
     if (imgCount < 9){
-      console.log("aaa");
       removeClass(imgCount)
       imgCount = imgCount + 1
       addClass(imgCount)
     } else {
-      console.log("bbb");
       imgCount = imgCount + 1
       $("#is-add").removeClass();
       $(".is-upload-box-container__box--text").text("");
@@ -140,8 +137,6 @@ $(document).on('turbolinks:load', function(){
       $("#is-add").attr("for",`is-img-${isImgId+1}`);
 //変更後のlabelのforを取得
        isLabelFor = $(".is-upload-box-container").find("#is-add").attr("for")
-       isCount = isCount + 1
-       console.log(imgCount)
   }
     reader.readAsDataURL(file);
   });
@@ -150,8 +145,6 @@ $(document).on('turbolinks:load', function(){
 ////削除ボタンの処理//////////////////////////////////////////////////////////////
   $(".is-upload-box-container").on("click",".is-image-li__under--e",function(e){
     e.preventDefault();
-    console.log(imgCount)
-    isCount = isCount -1
 //削除対象のliのIDを取得
     var imgId = $(this).parent().parent().attr("id");
 //liのidに紐づくinputタグのdata-idを取得

--- a/app/assets/stylesheets/modules/itemsell.scss
+++ b/app/assets/stylesheets/modules/itemsell.scss
@@ -4,6 +4,7 @@
   display: block;
   clear: both;
 }
+
 .is-left{
     float: left;
   }
@@ -83,6 +84,55 @@
           display: block;
           width: 620px;
           margin: 16px auto 0;
+          .is-add-image{
+            display: inline;
+            .is-image-ul{
+              display: inline;
+              float: left;
+              .is-image-li:first-of-type{
+                margin-left: 0;
+              }
+              .is-image-li:nth-of-type(6){
+                margin-left: 0;
+              }
+              .is-image-li{
+                margin-left: 0;
+                width: 116px;
+                margin: 0 0 10px 7px;
+                position: relative;
+                display: inline-block;
+                border: 1px solid #eee;
+                vertical-align: top;
+                img{
+                   width: 100%;
+                  height: auto;
+                }
+                &__figure{
+                  line-height: 116px;
+                  width: auto;
+                  padding: 0;
+                  height: 116px;
+                  position: relative;
+                  overflow: hidden;
+                  background: #f5f5f5;
+                  margin: 0;
+                }
+                &__under{
+                  font-size: 14px;
+                  display: flex;
+                  &--e{
+                    display: inline-block;
+                    width: 50%;
+                    background: #f5f5f5;
+                    line-height: 44px;
+                    text-align: center;
+                    color: #0099e8;
+                    text-decoration: none;
+                  }
+                }
+               }
+              }
+            }
           &__box{
             width: 100%;
              margin-left: 0;
@@ -114,6 +164,27 @@
             word-wrap: break-word;
             }
           }
+            .is-item-1{
+              width: 470px;
+              margin-left: 2%;
+            }
+            .is-item-2{
+              width: 350px;
+              margin-left: 2%;
+            }
+            .is-item-3{
+              width: 220px;
+              margin-left: 2%;
+            }
+            .is-item-4{
+              width: 90px;
+              margin-left: 2%;
+            }
+             .is-item-5{
+              width: 100%;
+              margin-left: 2%;
+            }
+        }
       }
     }
     .is-sell-content{
@@ -229,4 +300,4 @@
     }
   }
 }
-}
+

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,6 @@ class ItemsController < ApplicationController
   end
 
   def create
-    binding.pry
     @item_form = ItemForm.new(item_params)
     if @item_form.save
         redirect_to root_path

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,33 @@
 class ItemsController < ApplicationController
   def new
+    @item_form = ItemForm.new
   end
 
   def create
+    binding.pry
+    @item_form = ItemForm.new(item_params)
+    if @item_form.save
+        redirect_to root_path
+      else
+        redirect_to 'new'
+    end
+  end
+
+  private
+
+  def item_params
+    params.require(:item_form).permit(
+      :name,
+      :description,
+      :category_id,
+      :brand_id,
+      :status,
+      :delivery_fee,
+      :delivery_method,
+      :prefecture_id,
+      :delivery_date,
+      :price,
+       { :image => [] }
+      ).merge(user_id:current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,7 +26,7 @@ class ItemsController < ApplicationController
       :prefecture_id,
       :delivery_date,
       :price,
-       { :image => [] }
+       { :images => [] }
       ).merge(user_id:current_user.id)
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,3 +1,4 @@
 class Image < ApplicationRecord
-  belomgs_to :item
+  belongs_to :item, optional: true
+  mount_uploader :image, ImageUploader
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,4 @@
 class Item < ApplicationRecord
-  # belongs_to_active_hash :prefecture
   belongs_to :category
   belongs_to :brand
   has_many :images, dependent: :destroy
@@ -12,16 +11,16 @@ class Item < ApplicationRecord
                   so_bad:    4,
                   very_bad:  5
   }
-  enum dfee: {
+  enum delivery_fee: {
                   include:  0,
                   exclude:  1
   }
-  enum ddate: {
+  enum delivery_date: {
                         one_to_two:    0,
                         two_to_three:  1,
                         four_to_seven: 2
   }
-  enum demethod: {
+  enum delivery_method: {
                           undecided:           0,
                           easy_mercari_mail:   1,
                           yu_yu_mercari_mail:  2,
@@ -46,4 +45,5 @@ class Item < ApplicationRecord
                 four_XL: 8,
                 FREE_SIZE: 9
   }
+
 end

--- a/app/models/item_form.rb
+++ b/app/models/item_form.rb
@@ -1,0 +1,28 @@
+class ItemForm
+    include ActiveModel::Model
+
+  attr_accessor       :name,
+                      :description,
+                      :category_id,
+                      :brand_id,
+                      :status,
+                      :delivery_fee,
+                      :delivery_method,
+                      :prefecture_id,
+                      :delivery_date,
+                      :price,
+                      :image,
+                      :user_id
+
+  def save
+    binding.pry
+    return false if invalid?
+    item = Item.new(name: name,description: description,category_id: category_id,brand_id: brand_id,status: status,delivery_fee: delivery_fee,delivery_method: delivery_method,prefecture_id: prefecture_id,delivery_date: delivery_date,price: price,user_id:user_id)
+    image.each do |i|
+      item.images.new(image: i)
+      item.save
+    end
+  end
+
+
+end

--- a/app/models/item_form.rb
+++ b/app/models/item_form.rb
@@ -15,7 +15,6 @@ class ItemForm
                       :user_id
 
   def save
-    binding.pry
     return false if invalid?
     item = Item.new(name: name,description: description,category_id: category_id,brand_id: brand_id,status: status,delivery_fee: delivery_fee,delivery_method: delivery_method,prefecture_id: prefecture_id,delivery_date: delivery_date,price: price,user_id:user_id)
     image.each do |i|

--- a/app/models/item_form.rb
+++ b/app/models/item_form.rb
@@ -11,13 +11,13 @@ class ItemForm
                       :prefecture_id,
                       :delivery_date,
                       :price,
-                      :image,
+                      :images,
                       :user_id
 
   def save
     return false if invalid?
     item = Item.new(name: name,description: description,category_id: category_id,brand_id: brand_id,status: status,delivery_fee: delivery_fee,delivery_method: delivery_method,prefecture_id: prefecture_id,delivery_date: delivery_date,price: price,user_id:user_id)
-    image.each do |i|
+    images.each do |i|
       item.images.new(image: i)
       item.save
     end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,47 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+   include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+  process resize_to_fit: [800, 800]
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -17,9 +17,9 @@
               .is-add-image
                 .is-image-ul.item-0
                   %ul#is-image-ul-2
-              = f.label :image ,class: "is-upload-box-container__box" ,id: "is-add",for: "is-img-0" do
+              = f.label :images ,class: "is-upload-box-container__box" ,id: "is-add",for: "is-img-0" do
                 .is-add-up
-                  = f.file_field :image,id: "is-img-0",multiple: true,data: {id: 0},class: "is-upload-box-container__box--file is-up-img"
+                  = f.file_field :images,id: "is-img-0",multiple: true,data: {id: 0},class: "is-upload-box-container__box--file is-up-img"
                   %pre.is-upload-box-container__box--text ドラッグアンドドロップまたはクリックしてファイルをアップロード
           .is-sell-content
             .is-form-group

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -4,17 +4,23 @@
     %section.is-section
       %h2.is-m-header 商品の情報を入力
       .is-form
-        = form_with model: Item.new  do |f|
+        = form_with model: @item_form, url: items_path do |f|
           .is-upload-box
             .is-upload-box__head
               %h3.is-upload-box__head--text 出品画像
               %span.is-upload-box__head--red 必須
             %p.is-upload-box__head-p 最大10枚までアップロードできます
             .is-upload-box-container.clearfix
-              = f.label :image_id ,class: "is-upload-box-container__box" do
-                = file_field :image,:id,class: "is-upload-box-container__box--file"
-                %pre.is-upload-box-container__box--text ドラッグアンドドロップまたはクリックしてファイルをアップロード
-                = fa_icon ("camera")
+              .is-add-image
+                .is-image-ul.item-0
+                  %ul#is-image-ul-1
+              .is-add-image
+                .is-image-ul.item-0
+                  %ul#is-image-ul-2
+              = f.label :image ,class: "is-upload-box-container__box" ,id: "is-add",for: "is-img-0" do
+                .is-add-up
+                  = f.file_field :image,id: "is-img-0",multiple: true,data: {id: 0},class: "is-upload-box-container__box--file is-up-img"
+                  %pre.is-upload-box-container__box--text ドラッグアンドドロップまたはクリックしてファイルをアップロード
           .is-sell-content
             .is-form-group
               = f.label :name ,:商品名,class: "is-form-group__label"
@@ -31,12 +37,17 @@
                 = f.label :category_id ,:カテゴリー,class: "is-form-group__label"
                 %span.is-form-group__span 必須
                 .is-select-wrap
-                  = f.select :category_id,{}, {}, {class: "is-form-group__select"}
+                  = f.select :category_id,Category.all.map{|k| [k.name, k.id]}, {}, {class: "is-form-group__select"}
+              .is-form-group
+                = f.label :brand_id ,:ブランド,class: "is-form-group__label"
+                %span.is-form-group__span 必須
+                .is-select-wrap
+                  = f.select :brand_id,Brand.all.map{|k| [k.name, k.id]}, {}, {class: "is-form-group__select"}
               .is-form-group
                 = f.label :status ,:商品の状態,class: "is-form-group__label"
                 %span.is-form-group__span 必須
                 .is-select-wrap
-                  = f.select :status,Item.statuses.keys.map {|k| [t("enums.items.status.#{k}"), k]},{}, {class: "is-form-group__select"}
+                  = f.select :status,Item.statuses.keys.map {|k| [t("enums.item.status.#{k}"), k]},{}, {class: "is-form-group__select"}
           .is-sell-content.clearfix
             %h3.is-sell-sub-head 配送について
             .is-sell-form-box
@@ -44,7 +55,12 @@
                 = f.label :delivery_fee ,:配送料の負担 ,class: "is-form-group__label"
                 %span.is-form-group__span 必須
                 .is-select-wrap
-                  = f.select :delivery_fee,Item.dfees.keys.map {|k| [t("enums.items.dfee.#{k}"), k]}, {}, {class: "is-form-group__select"}
+                  = f.select :delivery_fee,Item.delivery_fees.keys.map{|k| [t("enums.item.delivery_fee.#{k}"), k]}, {}, {class: "is-form-group__select"}
+              .is-form-group
+                = f.label :delivery_method ,:配送料の方法 ,class: "is-form-group__label"
+                %span.is-form-group__span 必須
+                .is-select-wrap
+                  = f.select :delivery_method,Item.delivery_methods.keys.map{|k| [t("enums.item.delivery_method.#{k}"), k]}, {}, {class: "is-form-group__select"}
               .is-form-group
                 = f.label :prefecture_id,:発送元の地域,class: "is-form-group__label"
                 %span.is-form-group__span 必須
@@ -54,7 +70,7 @@
                 = f.label :delivery_date,:発送までの日数,class: "is-form-group__label"
                 %span.is-form-group__span 必須
                 .is-select-wrap
-                  = f.select :delivery_date,Item.ddates.keys.map {|k| [t("enums.items.ddate.#{k}"), k]}, {}, {class: "is-form-group__select"}
+                  = f.select :delivery_date,Item.delivery_dates.keys.map {|k| [t("enums.item.delivery_date.#{k}"), k]}, {}, {class: "is-form-group__select"}
           .is-sell-content.clearfix
             %h3.is-sell-sub-head 販売価格(300〜9,999,999)
             .is-sell-form-box

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,7 +1,7 @@
 ja:
   enums:
-    items:
-      dmethod:
+    item:
+      delivery_method:
         undecided:            未定
         easy_mercari_mail:    らくらくメルカリ便
         yu_yu_mercari_mail:   ゆうゆうメルカリ便
@@ -20,11 +20,11 @@ ja:
         bad:                   やや傷や汚れあり
         so_bad:                傷や汚れあり
         very_bad:              全体的に状態悪い
-      ddate:
+      delivery_date:
         one_to_two:             1~2日で発送
         two_to_three:           2~3日で発送
         four_to_seven:          4~7日で発送
-      dfee:
+      delivery_fee:
         include:              送料込み(出品者負担)
         exclude:              着払い(購入者負担)
       size:


### PR DESCRIPTION
# why
 商品出品画面を実装するため

# what

- carrierwaveの導入
- 親モデル(item)に紐づく子モデル(image)を一つのフォームで登録
   - ItemFormモデルの作成
- 画像を複数枚登録と削除をjqueryを用いて削除
- viewの修正
   - enumとactivehashを利用したセレクトオプションの実装 
