### PR TITLE
商品詳細ページの登録された画像表示

### DIFF
--- a/app/assets/javascripts/item_show.js
+++ b/app/assets/javascripts/item_show.js
@@ -8,6 +8,8 @@ $(function() {
     arrows: false,
   });
 
+  $('.is-thumbnails__item:first').addClass('current');
+
   $thumbs.on('mouseover', function(e){
     e.preventDefault();
     var index = $thumbs.index(this);

--- a/app/assets/stylesheets/modules/items_show.scss
+++ b/app/assets/stylesheets/modules/items_show.scss
@@ -25,18 +25,19 @@
     .is-slider{
       height: 300px;
       &__item{
-        display: flex;
-        align-items: center;
         width: 300px;
         height: 300px;
         text-align: center;
+        overflow: hidden;
+        position: relative;
         img{
           height: 100%;
           width: auto;
-        }
-        .wider{
-          width: 100%;
-          height: auto;
+          margin: 0 auto;
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translateY(-50%) translateX(-50%);
         }
       }
     }
@@ -52,6 +53,10 @@
         overflow: hidden;
         img{
           width:100%;
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translateY(-50%) translateX(-50%);
         }
         &::before {
           opacity: 1;
@@ -65,6 +70,7 @@
           height: 100%;
           background-color: rgba(255,255,255,.5);
           transition: opacity .2s ease-out;
+          z-index: 100;
         }
         &.current {
           &::before {

--- a/app/assets/stylesheets/modules/items_show.scss
+++ b/app/assets/stylesheets/modules/items_show.scss
@@ -20,26 +20,33 @@
   &__photos {
     float: left;
     width: 300px;
-    height: 375px;
+    min-height: 360px;
     background: #fafafa;
     .is-slider{
-      width: 300px;
       height: 300px;
-      text-align: center;
-      position: relative;
       &__item{
+        display: flex;
+        align-items: center;
+        width: 300px;
+        height: 300px;
+        text-align: center;
         img{
-          height: 300px;
-          margin: 0 auto;
+          height: 100%;
+          width: auto;
+        }
+        .wider{
+          width: 100%;
+          height: auto;
         }
       }
     }
     .is-thumbnails{
       display: flex;
+      flex-wrap: wrap;
       &__item{
         position: relative;
         cursor: pointer;
-        width: auto;
+        width: 75px;
         height: 75px;
         text-align: center;
         overflow: hidden;
@@ -90,7 +97,6 @@
         border: 1px solid #f5f5f5;
       }
     }
-
     &__icons--one{
       display: inline-block;
       margin: 8px 16px 0 0;
@@ -112,6 +118,17 @@
       color: #0099e8;
     }
   }
+}
+.is-many-photos{
+  .is-thumbnails__item{
+    width: 60px;
+    height: 60px;
+  }
+  .is-item__detail{
+    height: 420px;
+  }
+}
+.is-item{
   &__price{
     margin: 24px 0 0;
     text-align: center;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,28 +26,18 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+    other_items = Item.where.not(id: params[:id])
 
-    near_items = Item.where(category_id: @item.category.id).reject{|i| i[:id] == params[:id]}
+    near_items = other_items.where(category_id: @item.category.id)
     @prev_item = near_items[rand(near_items.length)]
-    more_near_items = near_items.reject{|i| i[:id] == @prev_item[:id] }
+    more_near_items = near_items.where.not(id: @prev_item.id)
     @next_item = more_near_items[rand(more_near_items.length)]
 
     @comment = Comment.new
     @comments = @item.comments
 
-    max_i = Item.where(user_id: @item.user.id).length
-    if max_i < 7
-      @user_items = Item.where(user_id: @item.user.id)
-    else
-      @user_items = Item.where(user_id: @item.user.id)[max_i-6,max_i]
-    end
-
-    max_c = Item.where(category_id: @item.category.id).length
-    if max_c < 7
-      @category_items = Item.where(category_id: @item.category.id)
-    else
-      @category_items = Item.where(category_id: @item.category.id)[max_c-6,max_c]
-    end
+    @user_items = other_items.where(user_id: @item.user.id).limit(6)
+    @category_items = other_items.where(category_id: @item.category.id).limit(6)
   end
 
   private

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -142,7 +142,7 @@
               = link_to "#{@item.user.nickname}さんのその他の出品", "", class: "items-box-container__title__topic"
             .is-item__relation__box__contents.clearfix
               - @user_items.each do |item|
-              = render 'items/items_top/item', item:item
+                = render 'items/items_top/item', item:item
         - if @category_items.length != 0
           %section.is-item__relation__box
             %h2.is-item__ralation__box__title

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -136,17 +136,19 @@
             = link_to '' do
               = fa_icon 'pinterest-square'
       .is-item__relation
-        %section.is-item__relation__box
-          %h2.is-item__ralation__box__title
-            = link_to "#{@item.user.nickname}さんのその他の出品", "", class: "items-box-container__title__topic"
-          .is-item__relation__box__contents.clearfix
-            - @user_items.each do |item|
+        - if @user_items.length != 0
+          %section.is-item__relation__box
+            %h2.is-item__ralation__box__title
+              = link_to "#{@item.user.nickname}さんのその他の出品", "", class: "items-box-container__title__topic"
+            .is-item__relation__box__contents.clearfix
+              - @user_items.each do |item|
               = render 'items/items_top/item', item:item
-        %section.is-item__relation__box
-          %h2.is-item__ralation__box__title
-            = link_to "#{@item.category.name} その他の出品", "", class: "items-box-container__title__topic"
-          .is-item__relation__box__contents.clearfix
-            - @category_items.each do |item|
-              = render 'items/items_top/item', item:item
+        - if @category_items.length != 0
+          %section.is-item__relation__box
+            %h2.is-item__ralation__box__title
+              = link_to "#{@item.category.name} その他の出品", "", class: "items-box-container__title__topic"
+            .is-item__relation__box__contents.clearfix
+              - @category_items.each do |item|
+                = render 'items/items_top/item', item:item
 
   = render 'users/top-footer'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,35 +1,23 @@
 .is-wrapper
-
   = render 'users/top-header'
   = render 'users/bread-crumbs'
 
 
-  %section.is-item
+
+  %section{ class: "#{@item.images.length < 5 ? 'is-item' : 'is-item is-many-photos' }"}
     %h1.is-item__name #{@item.name}
     .is-item__main.clearfix
       .is-item__photos
         .is-slider
-          .is-slider__item
-            = image_tag("https://static.mercdn.net/item/detail/orig/photos/m15574349852_1.jpg?1553737753")
-          .is-slider__item
-            = image_tag("https://static.mercdn.net/item/detail/orig/photos/m15574349852_2.jpg?1553737753")
-          .is-slider__item
-            = image_tag("https://static.mercdn.net/item/detail/orig/photos/m51888120989_3.jpg?1553688994")
-          .is-slider__item
-            = image_tag("https://static.mercdn.net/item/detail/orig/photos/m51888120989_4.jpg?1553688994")
+          - @item.images.each do |img|
+            .is-slider__item
+              = image_tag(img.image.url)
         .is-thumbnails
-          .is-thumbnails__item.current
-            = link_to '' do
-              = image_tag("https://static.mercdn.net/item/detail/orig/photos/m15574349852_1.jpg?1553737753")
-          .is-thumbnails__item
-            = link_to '' do
-              = image_tag("https://static.mercdn.net/item/detail/orig/photos/m15574349852_2.jpg?1553737753")
-          .is-thumbnails__item
-            = link_to '' do
-              = image_tag("https://static.mercdn.net/item/detail/orig/photos/m51888120989_3.jpg?1553688994")
-          .is-thumbnails__item
-            = link_to '' do
-              = image_tag("https://static.mercdn.net/item/detail/orig/photos/m51888120989_4.jpg?1553688994")
+          - @item.images.each do |img|
+            .is-thumbnails__item
+              = link_to '' do
+                = image_tag(img.image.url)
+
       %table.is-item__detail
         %tr
           %th 出品者
@@ -83,16 +71,20 @@
         %tr
           %th 発送日の目安
           %td #{@item.delivery_date_i18n}
+
     .is-item__price
       %span.is-item__price--bold
         = converting_to_jpy(@item.price)
       %span.is-item__price--tax (税込)
       %span.is-item__price--shipping-fee
         = "#{@item.delivery_fee_i18n}".gsub(/\(.+\)/,"")
+
     = link_to "購入画面に進む", itemconfirm_path(@item), class: "is-item__buy-btn"
+
     .is-item__description
       %p.is-item__description--inner
         #{@item.description}
+
     .is-item__btns.clearfix
       .is-item__btns--left
         = render 'likes/like'
@@ -104,6 +96,8 @@
           = fa_icon "lock", class: "is-item__btns--right--safe__icon"
           %span.is-item__btns--right--safe__text あんしん・あんぜんへの取り組み
 
+
+
   .is-item__comment-block
     .is-item__comment__wrapper
       .is-item__comments
@@ -114,6 +108,7 @@
         = form_for [@item, @comment], html:{id: 'comment-form'} do |f|
           = f.text_area :comment, class: 'is-item__comment-form__textarea', placeholder: 'コメントを書いてください'
           = f.submit 'コメントする', class: 'is-item__comment-form__btn'
+
       %ul.is-item__navi.clearfix
         %li.is-item__navi--prev
           = link_to item_path(@prev_item), data: {"turbolinks"=>false}do
@@ -123,6 +118,7 @@
           = link_to item_path(@next_item), data: {"turbolinks"=>false} do
             = @next_item.name
             = fa_icon "angle-right"
+
       .is-item__social-media-box
         .is-item__social-medias-text
         %ul.is-item__social-medias
@@ -135,6 +131,7 @@
           %li
             = link_to '' do
               = fa_icon 'pinterest-square'
+
       .is-item__relation
         - if @user_items.length != 0
           %section.is-item__relation__box
@@ -150,5 +147,7 @@
             .is-item__relation__box__contents.clearfix
               - @category_items.each do |item|
                 = render 'items/items_top/item', item:item
+
+
 
   = render 'users/top-footer'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -15,8 +15,7 @@
         .is-thumbnails
           - @item.images.each do |img|
             .is-thumbnails__item
-              = link_to '' do
-                = image_tag(img.image.url)
+              = image_tag(img.image.url)
 
       %table.is-item__detail
         %tr

--- a/app/views/users/_camera-btn.html.haml
+++ b/app/views/users/_camera-btn.html.haml
@@ -1,4 +1,4 @@
 .camera-container
-  = link_to itemsell_path , class: "camera-sell-btn" do
+  = link_to new_item_path , class: "camera-sell-btn" do
     .camera 出品
     .i.fa.fa-camera

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2019_03_31_064615) do
-
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
# What
・商品出品ページで登録された画像を商品詳細ページで表示
・商品詳細ページの関連商品から、現在いる商品詳細ページの商品を除外

# Why
登録した画像を表示するため
無駄な表示を減らすため
