### PR TITLE
売り切れている時の商品詳細ページ

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -98,18 +98,21 @@
       font-size: 16px;
       line-height: 1.5;
     }
-    input{
-      width: 100%;
-      margin: 8px 0 0;
-      text-align: center;
-      background: #aaa;
-      border: 1px solid #aaa;
-      color: #fff;
-      line-height: 48px;
-    }
     p{
       padding: 8px;
       background: #fff6de;
     }
   }
+}
+.is-item__comment-form__btn{
+  width: 100%;
+  margin: 8px 0 0;
+  text-align: center;
+  background: #aaa;
+  border: 1px solid #aaa;
+  color: #fff;
+  line-height: 48px;
+}
+.is-gray{
+  background: #888;
 }

--- a/app/assets/stylesheets/modules/items_show.scss
+++ b/app/assets/stylesheets/modules/items_show.scss
@@ -22,6 +22,7 @@
     width: 300px;
     min-height: 360px;
     background: #fafafa;
+    position: relative;
     .is-slider{
       height: 300px;
       &__item{
@@ -345,7 +346,7 @@
   }
 }
 .is-modal{
-  z-index:1;
+  z-index: 3;
   display: none;
   position:fixed;
   top:0;
@@ -358,7 +359,7 @@
     width: 600px;
     margin: 20px auto;
     background: #fff;
-    z-index: 2;
+    z-index: 4;
   }
   &__body{
     padding: 64px;
@@ -385,8 +386,36 @@
     background: #fff;
   }
 }
+.is-soldout-badge::after{
+  border-width: 120px 120px 0 0;
+  display: block;
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: #ea352d transparent transparent transparent;
+}
+.is-sold{
+  position: absolute;
+  top: 24px;
+  left: 0;
+  font-size: 24px;
+  z-index: 2;
+  color: #fff;
+  transform: rotate(-45deg);
+  letter-spacing: 2px;
+  font-weight: 600;
+}
+.is-gray{
+  background: #888;
+}
 .clearfix:after{
   content: '';
   display: block;
   clear: both;
 }
+

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,8 +14,6 @@ class UsersController < ApplicationController
   end
 
   def top
-
-    
   end
 
   def mypage

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -57,7 +57,10 @@ class Item < ApplicationRecord
                 four_XL: 8,
                 FREE_SIZE: 9
   }
-
+  enum item_status: {
+                  on_sale:  0,
+                  sold_out:  1
+  }
 
 validates :name, presence: true
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -21,7 +21,7 @@
     %h1.is-item__name #{@item.name}
     .is-item__main.clearfix
       .is-item__photos
-        - if @item.item_status != 0
+        - if @item.item_status == "sold_out"
           .is-soldout-badge
             .is-sold SOLD
         .is-slider
@@ -94,7 +94,7 @@
       %span.is-item__price--shipping-fee
         = "#{@item.delivery_fee_i18n}".gsub(/\(.+\)/,"")
     - if @item.user != current_user
-      - if @item.item_status == 0
+      - if @item.item_status == "on_sale"
         = link_to "購入画面に進む", new_item_order_path(@item), class: "is-item__buy-btn"
       - else
         .is-gray.is-item__buy-btn 売り切れました
@@ -134,7 +134,7 @@
         %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
         = form_for [@item, @comment], html:{id: 'comment-form'} do |f|
           = f.text_area :comment, class: 'is-item__comment-form__textarea', placeholder: 'コメントを書いてください'
-          - if @item.item_status == 0
+          - if @item.item_status == "on_sale"
             = f.submit 'コメントする', class: 'is-item__comment-form__btn'
           - else
             .is-item__comment-form__btn.is-gray 売り切れのためコメントできません

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -21,6 +21,9 @@
     %h1.is-item__name #{@item.name}
     .is-item__main.clearfix
       .is-item__photos
+        - if @item.status != 0
+          .is-soldout-badge
+            .is-sold SOLD
         .is-slider
           - @item.images.each do |img|
             .is-slider__item
@@ -91,7 +94,10 @@
       %span.is-item__price--shipping-fee
         = "#{@item.delivery_fee_i18n}".gsub(/\(.+\)/,"")
     - if @item.user != current_user
-      = link_to "購入画面に進む", new_item_order_path(@item), class: "is-item__buy-btn"
+      - if @item.status == 0
+        = link_to "購入画面に進む", new_item_order_path(@item), class: "is-item__buy-btn"
+      - else
+        .is-gray.is-item__buy-btn 売り切れました
 
     .is-item__description
       %p.is-item__description--inner
@@ -128,7 +134,10 @@
         %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
         = form_for [@item, @comment], html:{id: 'comment-form'} do |f|
           = f.text_area :comment, class: 'is-item__comment-form__textarea', placeholder: 'コメントを書いてください'
-          = f.submit 'コメントする', class: 'is-item__comment-form__btn'
+          - if @item.status == 0
+            = f.submit 'コメントする', class: 'is-item__comment-form__btn'
+          - else
+            .is-item__comment-form__btn.is-gray 売り切れのためコメントできません
 
       - if @item.user != current_user
         %ul.is-item__navi.clearfix
@@ -167,6 +176,5 @@
                 = link_to "#{@item.category.name} その他の出品", "#", class: "items-box-container__title__topic"
               .is-item__relation__box__contents.clearfix
                 = render partial: 'items/items_top/item', collection: @category_items, as: "item"
-
 
   = render 'users/top-footer'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -21,7 +21,7 @@
     %h1.is-item__name #{@item.name}
     .is-item__main.clearfix
       .is-item__photos
-        - if @item.status != 0
+        - if @item.item_status != 0
           .is-soldout-badge
             .is-sold SOLD
         .is-slider
@@ -94,7 +94,7 @@
       %span.is-item__price--shipping-fee
         = "#{@item.delivery_fee_i18n}".gsub(/\(.+\)/,"")
     - if @item.user != current_user
-      - if @item.status == 0
+      - if @item.item_status == 0
         = link_to "購入画面に進む", new_item_order_path(@item), class: "is-item__buy-btn"
       - else
         .is-gray.is-item__buy-btn 売り切れました
@@ -134,7 +134,7 @@
         %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
         = form_for [@item, @comment], html:{id: 'comment-form'} do |f|
           = f.text_area :comment, class: 'is-item__comment-form__textarea', placeholder: 'コメントを書いてください'
-          - if @item.status == 0
+          - if @item.item_status == 0
             = f.submit 'コメントする', class: 'is-item__comment-form__btn'
           - else
             .is-item__comment-form__btn.is-gray 売り切れのためコメントできません

--- a/app/views/users/itemconfirm.html.haml
+++ b/app/views/users/itemconfirm.html.haml
@@ -6,7 +6,7 @@
   %section.ib-content__item
     .ib-content__item-inner
       .ib-content__item-inner__image
-        = image_tag(@item.images[0].to_s, size:"148x148")
+        = image_tag(@item.images[0].image.to_s, size:"148x148")
       %p.ib-content__item-inner-name
         = @item.name
       = form_with url:item_orders_path(@item.id), local:true, html: {class: "ib-content__item-inner__form"} do |f|

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -39,7 +39,6 @@ ja:
         four_XL:              4XL(5L)以上
         FREE_SIZE:            FREE SIZE
 
-ja:
   activerecord:
     attributes:
       user:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,6 +81,21 @@ ActiveRecord::Schema.define(version: 2019_04_03_090053) do
     t.index ["user_id"], name: "fk_rails_1e09b5dabf"
   end
 
+  create_table "lower_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name"
+    t.integer "middle_category_id"
+  end
+
+  create_table "middle_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_middle_categories_on_category_id"
+  end
+
   create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "item_id", null: false
     t.bigint "user_id", null: false
@@ -96,20 +111,6 @@ ActiveRecord::Schema.define(version: 2019_04_03_090053) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["order_id"], name: "index_settlements_on_order_id"
-
-  create_table "lower_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "name"
-    t.integer "middle_category_id"
-  end
-
-  create_table "middle_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
-    t.bigint "category_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["category_id"], name: "index_middle_categories_on_category_id"
   end
 
   create_table "social_profiles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -160,9 +161,9 @@ ActiveRecord::Schema.define(version: 2019_04_03_090053) do
   add_foreign_key "items", "users"
   add_foreign_key "likes", "items"
   add_foreign_key "likes", "users"
+  add_foreign_key "middle_categories", "categories"
   add_foreign_key "orders", "items"
   add_foreign_key "orders", "users"
   add_foreign_key "settlements", "orders"
-  add_foreign_key "middle_categories", "categories"
   add_foreign_key "social_profiles", "users"
 end


### PR DESCRIPTION
# WHAT
・購入されたアイテムに売り切れラベルを追加
・購入ボタンを売り切れました表示に
・コメント送信ボタンを無効化

# WHY
購入できないものを購入できると思わせないように

実装画面
https://gyazo.com/a4ce501444ae6df8953bf62481b612ba