### PR TITLE
updateの修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show,:search]
 
   def index
     @ladies = Item.where(category_id: 1).order("created_at DESC").limit(4)
@@ -52,9 +53,13 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item_form = ItemForm.new(id:params[:id])
-    @item_form.update(item_params)
-    redirect_to root_path
+    @item_form = ItemForm.new(item_params.merge(id:params[:id]))
+    if @item_form.update
+        redirect_to root_path
+      else
+        @errors = @item_form.errors
+        render :edit
+    end
   end
 
 

--- a/app/models/item_form.rb
+++ b/app/models/item_form.rb
@@ -48,26 +48,47 @@ class ItemForm
 
   def save
     return false if invalid?
-    item = Item.new(name: name,description: description,category_id: category_id,brand_id: brand_id,status: status,delivery_fee: delivery_fee,delivery_method: delivery_method,prefecture_id: prefecture_id,delivery_date: delivery_date,price: price,user_id:user_id)
+    item = Item.new(item_params)
     images.each do |i|
       item.images.new(image: i)
       item.save
     end
   end
 
-  def update(params)
-    @item.update(params)
+  def update
+    @item = Item.find(id)
+    self.images = @item.images unless images
+    return false if invalid?
     if remove_images
       remove_images.each do |r|
         @item.images.find(r).destroy
       end
     end
-    if images
+    unless images == @item.images
       images.each do |i|
         @item.images.new(image: i)
         @item.save
       end
     end
+        @item.update(item_params)
+  end
+
+  private
+
+  def item_params
+    {
+      name: name,
+      description: description,
+      category_id: category_id,
+      brand_id: brand_id,
+      status: status,
+      delivery_fee: delivery_fee,
+      delivery_method: delivery_method,
+      prefecture_id: prefecture_id,
+      delivery_date: delivery_date,
+      price: price,
+      user_id:user_id
+    }
   end
 
 

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -124,12 +124,12 @@
                   .is-left
                     販売手数料(10%)
                   .is-right.is-sell-price__li--small#is-commission
-                    = "¥#{(@item_form.price * 0.1).round}"
+                    = "¥#{(@item_form.price.to_i * 0.1).round}" if @item_form.price
                 %li.clearfix.bold.is-sell-price__li
                   .is-left.is-bold
                     販売利益
                   .is-right.is-sell-price__li--large#is-profit
-                    = "¥#{(@item_form.price * 0.9).round}"
+                    = "¥#{(@item_form.price.to_i * 0.9).round}" if @item_form.price
           .is-sell-content
             %p.is-sell-content__p 禁止されている出品、行為を必ずご確認ください。
             %p.is-sell-content__p またブランド品でシリアルナンバー等がある場合はご記載ください。偽ブランドの販売は犯罪であり処罰される可能性があります。


### PR DESCRIPTION
# what
- ログインユーザーでないと商品出品・編集ができないように変更
- updateの際にバリデーション分岐を設定
- 現状ではupdate時にimagesのプロパティ値が取得できないため、画像の変更がなかった時は、imagesに今の値を代入
